### PR TITLE
fix: add path for query servicemonitor.

### DIFF
--- a/charts/databend-query/templates/servicemonitor.yaml
+++ b/charts/databend-query/templates/servicemonitor.yaml
@@ -12,4 +12,5 @@ spec:
       {{- include "databend-query.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: {{ .Values.serviceMonitor.port }}
+      path: /metrics
 {{- end }}


### PR DESCRIPTION
The metrics path of query has been updated to `/metrics`. This doc is outdated.