### PR TITLE
feat: support service use nodeport

### DIFF
--- a/charts/databend-query/templates/service.yaml
+++ b/charts/databend-query/templates/service.yaml
@@ -25,9 +25,9 @@ spec:
     {{- end }}
   selector:
     {{- include "databend-query.selectorLabels" . | nindent 4 }}
-      {{- if and (eq .Values.workload "statefulset") (not .Values.enableLoadBalance) }}
-      statefulset.kubernetes.io/pod-name: {{ include "databend-query.fullname" . }}-0
-      {{- end }}
+    {{- if and (eq .Values.workload "statefulset") (not .Values.enableLoadBalance) }}
+    statefulset.kubernetes.io/pod-name: {{ include "databend-query.fullname" . }}-0
+    {{- end }}
   {{- with .Values.service.sessionAffinity }}
   sessionAffinity: {{ .type }}
   sessionAffinityConfig:

--- a/charts/databend-query/templates/service.yaml
+++ b/charts/databend-query/templates/service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ include "databend-query.fullname" . }}
   labels:
     {{- include "databend-query.labels" . | nindent 4 }}
-    {{- with .Values.service.extraLabels }}
+      {{- with .Values.service.extraLabels }}
       {{- toYaml . | nindent 4 }}
-    {{- end }}
+      {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -16,15 +16,18 @@ spec:
   ports:
     {{- range $key, $val := .Values.service.ports }}
     - port: {{ $val }}
-      targetPort: {{ $key}}
+      targetPort: {{ $key }}
       protocol: TCP
       name: {{ $key }}
+      {{- if and (eq $.Values.service.type "NodePort") (hasKey $.Values.service.nodePorts $key) }}
+      nodePort: {{ index $.Values.service.nodePorts $key }}
+      {{- end }}
     {{- end }}
   selector:
     {{- include "databend-query.selectorLabels" . | nindent 4 }}
-    {{- if and (eq .Values.workload "statefulset") (not .Values.enableLoadBalance) }}
-    statefulset.kubernetes.io/pod-name: {{ include "databend-query.fullname" . }}-0
-    {{- end }}
+      {{- if and (eq .Values.workload "statefulset") (not .Values.enableLoadBalance) }}
+      statefulset.kubernetes.io/pod-name: {{ include "databend-query.fullname" . }}-0
+      {{- end }}
   {{- with .Values.service.sessionAffinity }}
   sessionAffinity: {{ .type }}
   sessionAffinityConfig:

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -50,7 +50,6 @@ service:
   # NodePort config (optional)
   nodePorts: {}
     # mysql: 30307  # If using nodeport, you can use this to specify the mysql port, default to 30307
-    mysql: 30307  # If use nodeport, you can use this to specify the mysql port,default is 30307
 
   # Annotations to add to the service
   annotations: {}

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -37,7 +37,7 @@ readinessProbe:
   enabled: true
 
 service:
-  type: ClusterIP  # or use NodePort
+  type: ClusterIP
   ports:
     metric: 7070
     admin: 8080
@@ -47,9 +47,9 @@ service:
     mysql: 3307
     ckhttp: 8124
 
-  # NodePort config（optional）
+  # NodePort config (optional)
   nodePorts:
-    mysql: 30307  # if mysql need nodePort
+    mysql: 30307  # If use nodeport, you can use this to specify the mysql port,default is 30307
 
   # Annotations to add to the service
   annotations: {}

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -48,7 +48,8 @@ service:
     ckhttp: 8124
 
   # NodePort config (optional)
-  nodePorts:
+  nodePorts: {}
+    # mysql: 30307  # If using nodeport, you can use this to specify the mysql port, default to 30307
     mysql: 30307  # If use nodeport, you can use this to specify the mysql port,default is 30307
 
   # Annotations to add to the service

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -49,7 +49,7 @@ service:
 
   # NodePort config (optional)
   nodePorts: {}
-    # mysql: 30307  # If using nodeport, you can use this to specify the mysql port, default to 30307
+    # mysql: 30307  # If using nodeport, you can use this to specify the mysql port
 
   # Annotations to add to the service
   annotations: {}

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -37,7 +37,7 @@ readinessProbe:
   enabled: true
 
 service:
-  type: ClusterIP  # 或 NodePort
+  type: ClusterIP  # or use NodePort
   ports:
     metric: 7070
     admin: 8080

--- a/charts/databend-query/values.yaml
+++ b/charts/databend-query/values.yaml
@@ -37,16 +37,19 @@ readinessProbe:
   enabled: true
 
 service:
-  type: ClusterIP
+  type: ClusterIP  # 或 NodePort
   ports:
     metric: 7070
     admin: 8080
     flight: 9090
-
     http: 8000
     flightsql: 8900
     mysql: 3307
     ckhttp: 8124
+
+  # NodePort config（optional）
+  nodePorts:
+    mysql: 30307  # if mysql need nodePort
 
   # Annotations to add to the service
   annotations: {}


### PR DESCRIPTION
Support databend-query service use NodePort service type to expose.